### PR TITLE
ci: add github actions to lint and add eslint to shared project

### DIFF
--- a/.github/workflows/ci-angular.yml
+++ b/.github/workflows/ci-angular.yml
@@ -2,6 +2,20 @@ name: CI Angular
 on:
   pull_request:
 jobs:
+  ci-angular-lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16, 18, 20]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
   ci-angular-admin-build:
     runs-on: ubuntu-latest
     strategy:

--- a/angular.json
+++ b/angular.json
@@ -340,17 +340,13 @@
             "outputPath": "dist/shared",
             "index": "projects/shared/src/index.html",
             "main": "projects/shared/src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": ["zone.js"],
             "tsConfig": "projects/shared/tsconfig.app.json",
             "assets": [
               "projects/shared/src/favicon.ico",
               "projects/shared/src/assets"
             ],
-            "styles": [
-              "projects/shared/src/styles.css"
-            ],
+            "styles": ["projects/shared/src/styles.css"],
             "scripts": []
           },
           "configurations": {
@@ -401,19 +397,23 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/shared/tsconfig.spec.json",
             "assets": [
               "projects/shared/src/favicon.ico",
               "projects/shared/src/assets"
             ],
-            "styles": [
-              "projects/shared/src/styles.css"
-            ],
+            "styles": ["projects/shared/src/styles.css"],
             "scripts": []
+          }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "lintFilePatterns": [
+              "projects/shared/**/*.ts",
+              "projects/shared/**/*.html"
+            ]
           }
         }
       }

--- a/projects/shared/.eslintrc.json
+++ b/projects/shared/.eslintrc.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../.eslintrc.json",
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "shared",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "shared",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "rules": {}
+    }
+  ]
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new job `ci-angular-lint` to the CI workflow. This job will run on multiple Node.js versions (16, 18, and 20) and perform linting checks, ensuring code quality and consistency.
- Chore: Updated ESLint configuration for TypeScript and HTML files in the shared project. The new rules enforce specific naming conventions for Angular directives and components, improving readability and maintainability of the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->